### PR TITLE
testing navigation with mockito and espresso

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'kotlin-android-extensions'
     id "androidx.navigation.safeargs.kotlin"
     id 'dagger.hilt.android.plugin'
 }
@@ -45,8 +46,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-
-
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
 
     // To create readable assertions, we can use the Truth library instead
     testImplementation "org.hamcrest:hamcrest-all:$hamcrestVersion"
@@ -72,8 +73,6 @@ dependencies {
 
     // Kotlin
     implementation "androidx.fragment:fragment-ktx:1.3.6"
-    // Testing Fragments in Isolation
-    androidTestImplementation "androidx.fragment:fragment-testing:1.3.6"
 
     //Dagger - Hilt
     implementation "com.google.dagger:hilt-android:2.38.1"
@@ -103,7 +102,8 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-core:2.28.2"
     androidTestImplementation 'com.google.dagger:hilt-android-testing:2.38.1'
     kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.38.1'
-    debugImplementation "androidx.fragment:fragment-testing:1.4.0-alpha10"
+    // Testing Fragments in Isolation
+    debugImplementation "androidx.fragment:fragment-testing:1.3.6"
 
 
     // Testing

--- a/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/data/local/ShoppingDataTest.kt
+++ b/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/data/local/ShoppingDataTest.kt
@@ -1,9 +1,6 @@
 package com.projects.shoppinglisttestingtutorial.data.local
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.room.Room
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import com.projects.shoppinglisttestingtutorial.getOrAwaitValue
 import com.projects.shoppinglisttestingtutorial.launchFragmentInHiltContainer
@@ -11,7 +8,6 @@ import com.projects.shoppinglisttestingtutorial.ui.ShoppingFragment
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
@@ -19,7 +15,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -32,7 +27,7 @@ class ShoppingDataTest {
     val hiltRule=HiltAndroidRule(this)
 
     @get:Rule
-    var instantTaskExecutorRule=InstantTaskExecutorRule()
+    val instantTaskExecutorRule=InstantTaskExecutorRule()
 
     @Inject @Named("test_db") lateinit var database: ShoppingItemDatabase
     private lateinit var  dao:ShoppingDao

--- a/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/repositories/FakeShoppingRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/repositories/FakeShoppingRepositoryAndroidTest.kt
@@ -1,0 +1,60 @@
+package com.projects.shoppinglisttestingtutorial.repositories
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.projects.shoppinglisttestingtutorial.data.local.ShoppingItem
+import com.projects.shoppinglisttestingtutorial.data.remote.responses.ImageResponse
+import com.projects.shoppinglisttestingtutorial.other.CustomResult
+
+class FakeShoppingRepositoryAndroidTest : ShoppingRepository {
+
+    private val shoppingItems = mutableListOf<ShoppingItem>()
+
+    private val observableShoppingItem = MutableLiveData<List<ShoppingItem>>(shoppingItems)
+    private val observableTotalPrice = MutableLiveData<Float>()
+
+    private var shouldReturnNetworkError = false
+
+    fun setShouldReturnNetworkError(value: Boolean) {
+        shouldReturnNetworkError = value
+    }
+
+    private fun refreshLiveData() {
+        observableShoppingItem.postValue(shoppingItems)
+        observableTotalPrice.postValue(getTotalPrice())
+    }
+
+    private fun getTotalPrice(): Float {
+        return shoppingItems.sumOf { shoppingItem ->
+            shoppingItem.price.toDouble()
+        }.toFloat()
+    }
+
+    override suspend fun insertShoppingItem(shoppingItem: ShoppingItem) {
+        shoppingItems.add(shoppingItem)
+        refreshLiveData()
+    }
+
+    override suspend fun deleteShoppingItem(shoppingItem: ShoppingItem) {
+        shoppingItems.remove(shoppingItem)
+        refreshLiveData()
+    }
+
+    override fun observeAllShoppingItems(): LiveData<List<ShoppingItem>> {
+        return observableShoppingItem
+    }
+
+    override fun observeTotalPrice(): LiveData<Float> {
+        return observableTotalPrice
+    }
+
+    override suspend fun searchForImage(imageQuery: String): CustomResult<ImageResponse> {
+        return if (shouldReturnNetworkError)
+            CustomResult.Error(Exception("Error"))
+        else
+            CustomResult.Success(data = ImageResponse(
+                hits = listOf(),
+                total = 0,
+                totalHits = 0))
+    }
+}

--- a/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/ui/AddShoppingItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/ui/AddShoppingItemFragmentTest.kt
@@ -1,0 +1,86 @@
+package com.projects.shoppinglisttestingtutorial.ui
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import com.projects.shoppinglisttestingtutorial.R
+import com.projects.shoppinglisttestingtutorial.getOrAwaitValue
+import com.projects.shoppinglisttestingtutorial.launchFragmentInHiltContainer
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@MediumTest
+@HiltAndroidTest
+@ExperimentalCoroutinesApi
+class AddShoppingItemFragmentTest{
+
+    @get:Rule
+    val hiltRule=HiltAndroidRule(this)
+
+    @get:Rule
+    val instantTaskExecutorRule=InstantTaskExecutorRule()
+
+    private lateinit var navController: NavController
+
+    @Before
+    fun setup(){
+        hiltRule.inject()
+        navController= mock(NavController::class.java)
+    }
+
+    @Test
+    fun pressBackButton_popBackStack(){
+
+        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+            Navigation.setViewNavController(requireView(),navController)
+        }
+
+        pressBack()
+
+        verify(navController).popBackStack()
+    }
+
+    @Test
+    fun clickOnImageView_navigateToImagePickFragment(){
+
+        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+            Navigation.setViewNavController(requireView(),navController)
+        }
+
+        onView(withId(R.id.ivShoppingImage)).perform(click())
+
+        verify(navController).navigate(
+            AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+        )
+    }
+
+    @Test
+    fun pressBackButton_setCurImageUrlToEmptyString(){
+        var testViewModel:ShoppingViewModel?=null
+
+        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+            Navigation.setViewNavController(requireView(),navController)
+            testViewModel=this.viewModel
+            this.viewModel.setCurImageUrl("imageUrl")
+        }
+
+        pressBack()
+
+        val curImageUrl=testViewModel?.curImageUrl?.getOrAwaitValue()
+
+        assertThat(curImageUrl,`is`(""))
+    }
+}

--- a/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/ui/ShoppingFragmentTest.kt
+++ b/app/src/androidTest/java/com/projects/shoppinglisttestingtutorial/ui/ShoppingFragmentTest.kt
@@ -1,0 +1,49 @@
+package com.projects.shoppinglisttestingtutorial.ui
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import com.projects.shoppinglisttestingtutorial.R
+import com.projects.shoppinglisttestingtutorial.launchFragmentInHiltContainer
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+
+@MediumTest
+@HiltAndroidTest
+@ExperimentalCoroutinesApi
+class ShoppingFragmentTest{
+
+    @get:Rule
+    val hiltRule=HiltAndroidRule(this)
+
+    @Before
+    fun setup(){
+        hiltRule.inject()
+    }
+
+    @Test
+    fun clickAddShoppingItem_navigateToShoppingItemFragment(){
+        val navController=mock(NavController::class.java)
+
+        launchFragmentInHiltContainer<ShoppingFragment> {
+            Navigation.setViewNavController(requireView(),navController)
+        }
+
+        onView(withId(R.id.fabAddShoppingItem)).perform(click())
+
+        verify(navController).navigate(
+            ShoppingFragmentDirections.actionShoppingFragmentToAddShoppingItemFragment()
+        )
+    }
+}

--- a/app/src/main/java/com/projects/shoppinglisttestingtutorial/ui/AddShoppingItemFragment.kt
+++ b/app/src/main/java/com/projects/shoppinglisttestingtutorial/ui/AddShoppingItemFragment.kt
@@ -1,10 +1,31 @@
 package com.projects.shoppinglisttestingtutorial.ui
 
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import com.projects.shoppinglisttestingtutorial.R
+import kotlinx.android.synthetic.main.fragment_add_shopping_item.*
 
 class AddShoppingItemFragment:Fragment(R.layout.fragment_add_shopping_item) {
-    private val viewModel:ShoppingViewModel by activityViewModels()
+    val viewModel:ShoppingViewModel by activityViewModels()
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        ivShoppingImage.setOnClickListener {
+            findNavController().navigate(
+                AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+            )
+        }
+
+        val callback=object :OnBackPressedCallback(true){
+            override fun handleOnBackPressed() {
+                viewModel.setCurImageUrl("")
+                findNavController().popBackStack()
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(callback)
+    }
 }

--- a/app/src/main/java/com/projects/shoppinglisttestingtutorial/ui/ShoppingFragment.kt
+++ b/app/src/main/java/com/projects/shoppinglisttestingtutorial/ui/ShoppingFragment.kt
@@ -1,10 +1,22 @@
 package com.projects.shoppinglisttestingtutorial.ui
 
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import com.projects.shoppinglisttestingtutorial.R
+import kotlinx.android.synthetic.main.fragment_shopping.*
 
 class ShoppingFragment : Fragment(R.layout.fragment_shopping) {
 
-    private val viewModel:ShoppingViewModel by activityViewModels()
+    private val viewModel: ShoppingViewModel by activityViewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        fabAddShoppingItem.setOnClickListener {
+            findNavController().navigate(ShoppingFragmentDirections
+                .actionShoppingFragmentToAddShoppingItemFragment())
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,11 +8,14 @@
     tools:context=".ui.MainActivity">
 
     <androidx.fragment.app.FragmentContainerView
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:defaultNavHost="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_shopping.xml
+++ b/app/src/main/res/layout/fragment_shopping.xml
@@ -6,7 +6,7 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".ui.MainActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/clShoppingItems"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/shoppingFragment">
+
+    <fragment
+        android:id="@+id/shoppingFragment"
+        android:name="com.projects.shoppinglisttestingtutorial.ui.ShoppingFragment"
+        android:label="ShoppingFragment" >
+        <action
+            android:id="@+id/action_shoppingFragment_to_addShoppingItemFragment"
+            app:destination="@id/addShoppingItemFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/addShoppingItemFragment"
+        android:name="com.projects.shoppinglisttestingtutorial.ui.AddShoppingItemFragment"
+        android:label="AddShoppingItemFragment" >
+        <action
+            android:id="@+id/action_addShoppingItemFragment_to_imagePickFragment"
+            app:destination="@id/imagePickFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/imagePickFragment"
+        android:name="com.projects.shoppinglisttestingtutorial.ui.ImagePickFragment"
+        android:label="ImagePickFragment" />
+</navigation>


### PR DESCRIPTION
To test the navigation graph we:
- Create a mock of the NavController Class
`navController= mock(NavController::class.java)`

- Then we launch our fragment using our custom Hilt launcher (we get a reference of the viewModel if needed)
```
launchFragmentInHiltContainer<AddShoppingItemFragment> {
            Navigation.setViewNavController(requireView(),navController)
            testViewModel=this.viewModel
            this.viewModel.setCurImageUrl("imageUrl")
        }
```
- We perform an action (a click, for example)
  -  Click on a widget
`onView(withId(R.id.ivShoppingImage)).perform(click())`
  - BackPressed
`pressBack()`
  - Click on RecyclerViewElement
```
        onView(withId(R.id.tasks_list))
            .perform(RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                hasDescendant(withText("TITLE1")), click()))
```
- Last, we verify we call the right function with the proper parameters
```
verify(navController).navigate(
            AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
        )
```

> IMPORTANT: We need to annotate our test class with `@MediumTest`, `@HiltAndroidTest` and `@ExperimentalCoroutinesApi` and  set the Rules for hilt and to handle Coroutines 
> ```
>    @get:Rule
>    val hiltRule=HiltAndroidRule(this)
>
>    @get:Rule
>    val instantTaskExecutorRule=InstantTaskExecutorRule()
>
>   private lateinit var navController: NavController
>
>    @Before
>    fun setup(){
>        hiltRule.inject()
>        ...
>   }
>```
